### PR TITLE
downgrade* 1.19.2 to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'maven-publish'
 
 archivesBaseName = 'swingthroughgrass'
 group = "com.exidex.swingthroughgrass"
-version = "1.19.2-1.10.0"
+version = "1.19-1.10.0"
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 minecraft {
-    mappings channel: 'official', version: '1.19.2'
+    mappings channel: 'official', version: '1.19'
 
     runs {
         client {
@@ -57,7 +57,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.19.2-43.0.0'
+    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
 }
 
 jar {
@@ -84,6 +84,6 @@ curseforge {
     project {
         id = '264353'
         releaseType = 'release'
-        addGameVersion '1.19.2'
+        addGameVersion '1.19'
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ description='''Don't let the grass be between you and your prey!'''
 [[dependencies.swingthroughgrass]]
     modId="forge"
     mandatory=true
-    versionRange="[41,)"
+    versionRange="[41.0.94,)"
     ordering="NONE"
     side="BOTH"
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[43,)"
+loaderVersion="[41,)"
 issueTrackerURL="https://github.com/Exidex/SwingThroughGrass/issues"
 license="MIT"
 
@@ -16,13 +16,13 @@ description='''Don't let the grass be between you and your prey!'''
 [[dependencies.swingthroughgrass]]
     modId="forge"
     mandatory=true
-    versionRange="[43,)"
+    versionRange="[41,)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.swingthroughgrass]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.19.2,)"
+    versionRange="[1.19,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
the 1.19.2 code would work fine for 1.19, but the current 1.19.2 build can't be used since its minimum mc/forge versions are too high. this PR changes it to use mc 1.19 and forge 41.1.0, which should make it compatible with any 1.19.x forge version at or above 1.19-41.0.94[^41.0.94].

[^41.0.94]: 41.0.94 renamed a few event-related things this mod uses, so 41.0.93 and below would need a separate build. this PR also specifies a minimum forge version of 41.0.94, so earlier 1.19 forge versions will fail gracefully with a graphical "Mod swingthroughgrass requires forge 41.0.94 or above" message rather than crashing at runtime.